### PR TITLE
Add Anticsrf middleware

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -4,4 +4,5 @@ module-item-spacing=compact
 sequence-blank-line=preserve-one
 single-case=compact
 break-cases = fit
+break-infix=fit-or-vertical
 parse-docstrings = true

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,5 @@
 profile = ocamlformat
+exp-grouping=preserve
 module-item-spacing=compact
 sequence-blank-line=preserve-one
 single-case=compact

--- a/dune-project
+++ b/dune-project
@@ -45,6 +45,7 @@
    (>= 0.8.9))
   (lwt
    (>= 5.4.1))
+  ptime
   (base64
    (>= 3.5.0))
   (mirage-crypto

--- a/examples/echo_server.ml
+++ b/examples/echo_server.ml
@@ -58,6 +58,7 @@ let app =
   (* Summer.memory_session ~cookie_name:"__session__" mem_storage *)
   let key = Summer.key 32 in
   Summer.cookie_session ~cookie_name:"__ID__" key
+  @@ Summer.anticsrf key
   @@ Summer.router router
   @@ Summer.not_found
 

--- a/examples/echo_server.ml
+++ b/examples/echo_server.ml
@@ -57,7 +57,7 @@ let app =
   (* let mem_storage = Summer.memory_storage () in *)
   (* Summer.memory_session ~cookie_name:"__session__" mem_storage *)
   let key = Summer.key 32 in
-  Summer.cookie_session ~cookie_name:"__ID__" key
+  Summer.cookie_session key
   @@ Summer.anticsrf key
   @@ Summer.router router
   @@ Summer.not_found

--- a/examples/echo_server.ml
+++ b/examples/echo_server.ml
@@ -15,7 +15,8 @@ let about _req =
   html
     (head (title (txt "Summer: Echo App")) [])
     (body [div [txt "About page"]])
-  |> Summer.tyxml |> Lwt.return
+  |> Summer.tyxml
+  |> Lwt.return
 
 let echo req =
   let+ body =
@@ -27,7 +28,8 @@ let say_hello name _req =
   html
     (head (title (txt "Summer: Echo App")) [])
     (body [div [txt ("Hello " ^ name ^ "!")]])
-  |> Summer.tyxml |> Lwt.return
+  |> Summer.tyxml
+  |> Lwt.return
 
 let counter : Summer.handler =
  fun req ->
@@ -41,7 +43,8 @@ let counter : Summer.handler =
   html
     (head (title (txt "Summer: Echo App")) [])
     (body [div [txt ("Hello " ^ string_of_int counter ^ "!")]])
-  |> Summer.tyxml |> Lwt.return
+  |> Summer.tyxml
+  |> Lwt.return
 
 let router =
   Wtr.create
@@ -55,7 +58,8 @@ let app =
   (* Summer.memory_session ~cookie_name:"__session__" mem_storage *)
   let key = Summer.key 32 in
   Summer.cookie_session ~cookie_name:"__ID__" key
-  @@ Summer.router router @@ Summer.not_found
+  @@ Summer.router router
+  @@ Summer.not_found
 
 let () =
   let port = ref 3000 in

--- a/lib/dune
+++ b/lib/dune
@@ -17,4 +17,6 @@
   fmt
   base64
   mirage-crypto
-  mirage-crypto-rng.unix))
+  mirage-crypto-rng.unix)
+ (preprocess
+  (pps lwt_ppx)))

--- a/lib/dune
+++ b/lib/dune
@@ -7,6 +7,8 @@
   http-cookie
   wtr
   csexp
+  ptime
+  ptime.clock.os
   tyxml
   angstrom
   uri

--- a/lib/summer.ml
+++ b/lib/summer.ml
@@ -529,14 +529,14 @@ let decrypt_base64 key contents =
 
 let anticsrf_token request = request.anticsrf_token
 
+(* Implements double submit anti-csrf technique.
+
+   https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#double-submit-cookie
+*)
 let anticsrf ?(protected_http_methods = [`POST; `PUT; `DELETE]) ?excluded_routes
     key' next request =
   let anticsrf_cookienm = "XSRF-TOKEN" in
   let anticsrf_tokname = "x-xsrf-token" in
-  (* Implements double submit anti-csrf mechnism.
-
-     https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#double-submit-cookie
-  *)
   let validate_anticsrf_token () =
     let method_protected =
       List.exists

--- a/lib/summer.ml
+++ b/lib/summer.ml
@@ -538,17 +538,17 @@ let anticsrf ?(protect_http_methods = [`POST; `PUT; `DELETE]) ?excluded_routes
      https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#double-submit-cookie
   *)
   let validate_anticsrf_token () =
-    let is_method_protected =
+    let method_protected =
       List.exists
         (fun method' -> method' = request.method')
         protect_http_methods
     in
-    let is_route_excluded =
+    let route_excluded =
       Option.bind excluded_routes (fun router ->
           Wtr.match' request.method' request.target router )
       |> Option.value ~default:false
     in
-    if is_method_protected && not is_route_excluded then
+    if method_protected && not route_excluded then
       let anticsrf_tok_cookie =
         match List.assoc_opt cookie_name (cookies request) with
         | Some c -> decrypt_base64 key' (Http_cookie.value c)

--- a/lib/summer.ml
+++ b/lib/summer.ml
@@ -549,7 +549,7 @@ let anticsrf ?(protected_http_methods = [`POST; `PUT; `DELETE]) ?excluded_routes
       |> Option.value ~default:false
     in
     if method_protected && not route_excluded then
-      let anticsrf_tok_cookie =
+      let anticsrf_cookie =
         match List.assoc_opt anticsrf_cookie_name (cookies request) with
         | Some c -> decrypt_base64 key' (Http_cookie.value c)
         | None ->
@@ -558,7 +558,7 @@ let anticsrf ?(protected_http_methods = [`POST; `PUT; `DELETE]) ?excluded_routes
                  (Format.sprintf "Anti-csrf cookie %s not found"
                     anticsrf_cookie_name ) )
       in
-      let* anticsrf_tok =
+      let* anticsrf_token =
         match List.assoc_opt anticsrf_token_name request.headers with
         | Some anticsrf_tok -> Lwt.return anticsrf_tok
         | None -> begin
@@ -572,9 +572,9 @@ let anticsrf ?(protected_http_methods = [`POST; `PUT; `DELETE]) ?excluded_routes
                         anticsrf_token_name ) )
           end
       in
-      let anticsrf_tok = decrypt_base64 key' anticsrf_tok in
-      if String.equal anticsrf_tok_cookie anticsrf_tok then Lwt.return ()
-      else raise (Request_error "Anti-csrf tokens donot match")
+      let anticsrf_token = decrypt_base64 key' anticsrf_token in
+      if String.equal anticsrf_cookie anticsrf_token then Lwt.return ()
+      else raise (Request_error "Anti-csrf tokens do not match")
     else Lwt.return ()
   in
   let* () = validate_anticsrf_token () in

--- a/lib/summer.ml
+++ b/lib/summer.ml
@@ -529,7 +529,7 @@ let decrypt_base64 key contents =
 
 let anticsrf_token request = request.anticsrf_token
 
-let anticsrf ?(protect_http_methods = [`POST; `PUT; `DELETE]) ?excluded_routes
+let anticsrf ?(protected_http_methods = [`POST; `PUT; `DELETE]) ?excluded_routes
     key' next request =
   let cookie_name = "XSRF-TOKEN" in
   let anticsrf_tokname = "x-xsrf-token" in
@@ -541,7 +541,7 @@ let anticsrf ?(protect_http_methods = [`POST; `PUT; `DELETE]) ?excluded_routes
     let method_protected =
       List.exists
         (fun method' -> method' = request.method')
-        protect_http_methods
+        protected_http_methods
     in
     let route_excluded =
       Option.bind excluded_routes (fun router ->

--- a/lib/summer.ml
+++ b/lib/summer.ml
@@ -497,6 +497,7 @@ let key_of_base64 s =
   | Error (`Msg msg) -> Error msg
 
 let encrypt_base64 key contents =
+  assert (String.length contents > 0) ;
   let key = Mirage_crypto.Chacha20.of_secret key in
   let nonce = Mirage_crypto_rng.generate nonce_size in
   let encrypted =
@@ -508,6 +509,7 @@ let encrypt_base64 key contents =
   |> Base64.(encode_string ~pad:false ~alphabet:uri_safe_alphabet)
 
 let decrypt_base64 key contents =
+  assert (String.length contents > 0) ;
   try
     let key = Mirage_crypto.Chacha20.of_secret key in
     let contents =

--- a/lib/summer.ml
+++ b/lib/summer.ml
@@ -521,7 +521,7 @@ let decrypt_base64 key contents =
     |> function
     | Some s -> Cstruct.to_string s
     | None -> request_error "Unable to decrypt contents"
-  with exn -> raise exn
+  with exn -> request_error "Decryption error: %s" (Printexc.to_string exn)
 
 (* Anti CSRF *)
 

--- a/lib/summer.ml
+++ b/lib/summer.ml
@@ -582,7 +582,7 @@ let anticsrf ?(protected_http_methods = [`POST; `PUT; `DELETE]) ?excluded_routes
   let request = {request with anticsrf_token} in
   let+ response = next request in
   let anticsrf_cookie =
-    Http_cookie.create ~http_only:false ~same_site:`Strict
+    Http_cookie.create ~http_only:true ~same_site:`Strict
       ~name:anticsrf_cookienm anticsrf_token
     |> Result.get_ok
   in

--- a/lib/summer.ml
+++ b/lib/summer.ml
@@ -69,8 +69,6 @@ and middleware = handler -> handler
 
 and key = Cstruct.t
 
-and anticsrf_token = {hmac: string; timestamp: string}
-
 exception Request_error of string
 
 let io_buffer_size = 65536 (* UNIX_BUFFER_SIZE 4.0.0 *)
@@ -483,6 +481,8 @@ let key sz =
   Lazy.force initialize_rng ;
   Mirage_crypto_rng.generate sz
 
+external key_to_cstruct : key -> Cstruct.t = "%identity"
+
 let key_to_base64 key =
   Cstruct.to_string key
   |> Base64.(encode_string ~pad:false ~alphabet:uri_safe_alphabet)
@@ -518,22 +518,11 @@ let decrypt_base64 key contents =
     | None -> Error "Unable to decrypt contents"
   with exn -> Error (Format.sprintf "%s" (Printexc.to_string exn))
 
-let anticsrf_token key =
-  let now = Ptime_clock.now () in
-  let timestamp = Ptime.to_rfc3339 ~space:false ~frac_s:6 now in
-  let hmac =
-    Cstruct.(
-      Mirage_crypto.Hash.SHA256.hmac ~key (of_string timestamp)
-      |> Cstruct.to_string)
-  in
-  {hmac; timestamp}
-
-let anticsrf_token_to_base64 token =
-  String.concat "" [token.hmac; token.timestamp]
+let anticsrf_token key' =
+  key 32
+  |> Mirage_crypto.Hash.SHA256.hmac ~key:key'
+  |> Cstruct.to_string
   |> Base64.(encode_string ~pad:false ~alphabet:uri_safe_alphabet)
-
-(* let verify_anticsrf_token key token = *)
-(*   let *)
 
 (* Session *)
 

--- a/lib/summer.ml
+++ b/lib/summer.ml
@@ -521,7 +521,7 @@ let decrypt_base64 key contents =
     |> function
     | Some s -> Cstruct.to_string s
     | None -> request_error "Unable to decrypt contents"
-  with exn -> request_error "%s" (Printexc.to_string exn)
+  with exn -> raise exn
 
 (* Anti CSRF *)
 

--- a/lib/summer.ml
+++ b/lib/summer.ml
@@ -615,8 +615,7 @@ let cookie_session ?expires ?max_age ?http_only ~cookie_name key next_handler
       |> function Ok v -> v | Error s -> raise (Request_error s)
     in
     let csexp =
-      Csexp.parse_string csexp
-      |> function
+      match Csexp.parse_string csexp with
       | Ok v -> v
       | Error (o, s) ->
           raise

--- a/lib/summer.ml
+++ b/lib/summer.ml
@@ -570,7 +570,7 @@ let anticsrf ?(protected_http_methods = [`POST; `PUT; `DELETE]) ?excluded_routes
     else Lwt.return ()
   in
   let%lwt () = validate_anticsrf_token () in
-  debug (fun k -> k "anti-csrf okay") ;
+  debug (fun k -> k "Anti-csrf okay") ;
 
   let anticsrf_token = key 32 |> Cstruct.to_string |> encrypt_base64 key' in
   let request = {request with anticsrf_token} in
@@ -690,8 +690,6 @@ let write_response fd {response_code; headers; body; cookies} =
   let body_len = Cstruct.length body in
 
   (* Add set-cookie headers if we have cookies. *)
-  debug (fun k -> k "Cookies: %d" (Smap.cardinal cookies)) ;
-
   let headers =
     if Smap.cardinal cookies > 0 then
       let headers =

--- a/lib/summer.ml
+++ b/lib/summer.ml
@@ -572,11 +572,11 @@ let anticsrf ?(protected_http_methods = [`POST; `PUT; `DELETE]) ?excluded_routes
           end
       in
       let anticsrf_tok = decrypt_base64 key' anticsrf_tok in
-      if String.equal anticsrf_tok_cookie anticsrf_tok then Lwt.return request
+      if String.equal anticsrf_tok_cookie anticsrf_tok then Lwt.return ()
       else raise (Request_error "Anti-csrf tokens donot match")
-    else Lwt.return request
+    else Lwt.return ()
   in
-  let* request = validate_anticsrf_token () in
+  let* () = validate_anticsrf_token () in
   let anticsrf_token = key 32 |> Cstruct.to_string |> encrypt_base64 key' in
   let request = {request with anticsrf_token} in
   let+ response = next request in

--- a/lib/summer.mli
+++ b/lib/summer.mli
@@ -187,7 +187,8 @@ val decrypt_base64 : key -> string -> (string, string) result
 
 (** {1 Anti-CSRF token} *)
 
-val anticsrf_token : key -> string
+val anticsrf_token : request -> string
+val anticsrf : ?protect_http_methods:method' list -> key -> middleware
 
 (** {1 Session} *)
 

--- a/lib/summer.mli
+++ b/lib/summer.mli
@@ -214,7 +214,6 @@ val session_all : request -> (string * string) list
 val cookie_session :
      ?expires:Http_cookie.date_time
   -> ?max_age:int64 (** Cookie duration in seconds *)
-  -> ?http_only:bool
   -> cookie_name:string
   -> key
   -> middleware
@@ -228,7 +227,6 @@ val memory_storage : unit -> memory_storage
 val memory_session :
      ?expires:Http_cookie.date_time
   -> ?max_age:int64 (** Cookie duration in seconds *)
-  -> ?http_only:bool
   -> cookie_name:string
   -> memory_storage
   -> middleware

--- a/lib/summer.mli
+++ b/lib/summer.mli
@@ -192,7 +192,12 @@ val decrypt_base64 : key -> string -> string
 (** {1 Anti-CSRF token} *)
 
 val anticsrf_token : request -> string
-val anticsrf : ?protect_http_methods:method' list -> key -> middleware
+
+val anticsrf :
+     ?protect_http_methods:method' list
+  -> ?excluded_routes:bool Wtr.t
+  -> key
+  -> middleware
 
 (** {1 Session} *)
 

--- a/lib/summer.mli
+++ b/lib/summer.mli
@@ -194,7 +194,7 @@ val decrypt_base64 : key -> string -> string
 val anticsrf_token : request -> string
 
 val anticsrf :
-     ?protect_http_methods:method' list
+     ?protected_http_methods:method' list
   -> ?excluded_routes:bool Wtr.t
   -> key
   -> middleware

--- a/lib/summer.mli
+++ b/lib/summer.mli
@@ -48,8 +48,10 @@ and middleware = handler -> handler
 
 and memory_storage
 
-(** A value used for encryption/decryption. *)
+(** Encryption/decryption key *)
 and key
+
+and anticsrf_token
 
 (** {1 Request} *)
 
@@ -183,6 +185,11 @@ val key_to_base64 : key -> string
 val key_of_base64 : string -> (key, string) result
 val encrypt_base64 : key -> string -> string
 val decrypt_base64 : key -> string -> (string, string) result
+
+(** {1 Anti-CSRF token} *)
+
+val anticsrf_token : key -> anticsrf_token
+val anticsrf_token_to_base64 : anticsrf_token -> string
 
 (** {1 Session} *)
 

--- a/lib/summer.mli
+++ b/lib/summer.mli
@@ -196,6 +196,8 @@ val anticsrf_token : request -> string
 val anticsrf :
      ?protected_http_methods:method' list
   -> ?excluded_routes:bool Wtr.t
+  -> ?cookie_name:string
+  -> ?token_header_name:string
   -> key
   -> middleware
 
@@ -214,7 +216,7 @@ val session_all : request -> (string * string) list
 val cookie_session :
      ?expires:Http_cookie.date_time
   -> ?max_age:int64 (** Cookie duration in seconds *)
-  -> cookie_name:string
+  -> ?cookie_name:string
   -> key
   -> middleware
 (** [cookie_session ~cookie_name key] is a middleware which stores session data
@@ -227,7 +229,7 @@ val memory_storage : unit -> memory_storage
 val memory_session :
      ?expires:Http_cookie.date_time
   -> ?max_age:int64 (** Cookie duration in seconds *)
-  -> cookie_name:string
+  -> ?cookie_name:string
   -> memory_storage
   -> middleware
 (** [memory_session ?expires ?max_age ?http_only ~cookie_name memory_storage] is

--- a/lib/summer.mli
+++ b/lib/summer.mli
@@ -51,8 +51,6 @@ and memory_storage
 (** Encryption/decryption key *)
 and key
 
-and anticsrf_token
-
 (** {1 Request} *)
 
 val method' : request -> method'
@@ -182,14 +180,14 @@ val key : int -> key
 (** [key sz] is {!type:key} which has [sz] count of bytes. *)
 
 val key_to_base64 : key -> string
+val key_to_cstruct : key -> Cstruct.t
 val key_of_base64 : string -> (key, string) result
 val encrypt_base64 : key -> string -> string
 val decrypt_base64 : key -> string -> (string, string) result
 
 (** {1 Anti-CSRF token} *)
 
-val anticsrf_token : key -> anticsrf_token
-val anticsrf_token_to_base64 : anticsrf_token -> string
+val anticsrf_token : key -> string
 
 (** {1 Session} *)
 

--- a/lib/summer.mli
+++ b/lib/summer.mli
@@ -183,7 +183,11 @@ val key_to_base64 : key -> string
 val key_to_cstruct : key -> Cstruct.t
 val key_of_base64 : string -> (key, string) result
 val encrypt_base64 : key -> string -> string
-val decrypt_base64 : key -> string -> (string, string) result
+
+val decrypt_base64 : key -> string -> string
+(** [decrypt_base64 key contents] decrypts [contents] using [key].
+
+    @raise exn if decryption fails *)
 
 (** {1 Anti-CSRF token} *)
 

--- a/summer.opam
+++ b/summer.opam
@@ -23,6 +23,7 @@ depends: [
   "uri" {>= "4.2.0"}
   "fmt" {>= "0.8.9"}
   "lwt" {>= "5.4.1"}
+  "ptime"
   "base64" {>= "3.5.0"}
   "mirage-crypto" {>= "0.10.3"}
   "mirage-crypto-rng" {>= "0.10.3"}


### PR DESCRIPTION
This PR adds Anti-CSRF middleware by implementing the double submit cookie technique as described in 
https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#double-submit-cookie